### PR TITLE
Make sure Past Clients link behaves like a link when hovered

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -189,6 +189,7 @@ h3 {
   font-size: 18px;
   line-height: 22px;
   transition: 0.5s all;
+  cursor: pointer;
 }
 
 .clientLink:hover {


### PR DESCRIPTION
Since the link "View Client List" doesn't have an "href" attribute, when you hover over it with a mouse, you get the text selection cursor and not the pointer cursor, like you do on a link. Fix it by adding this one attribute to the CSS.