### PR TITLE
Server-side Updates

### DIFF
--- a/portfolio.sh
+++ b/portfolio.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          portfolio
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start latest copy of portfolio.
+# Description:       Grabs and runs the latest copy of Jeff's portfolio on boot.
+### END INIT INFO
+
+dir="/home/node-web/portfolio"
+cmd="/home/node-web/portfolio/reboot-web.sh"
+user="node-web"
+
+name=`basename $0`
+pid_file="/var/run/$name.pid"
+stdout_log="/var/log/$name.log"
+stderr_log="/var/log/$name.err"
+
+get_pid() {
+    cat "$pid_file"
+}
+
+is_running() {
+    [ -f "$pid_file" ] && ps -p `get_pid` > /dev/null 2>&1
+}
+
+case "$1" in
+    start)
+    if is_running; then
+        echo "Already started"
+    else
+        echo "Starting $name"
+        cd "$dir"
+        if [ -z "$user" ]; then
+            sudo $cmd >> "$stdout_log" 2>> "$stderr_log" &
+        else
+            sudo -u "$user" $cmd >> "$stdout_log" 2>> "$stderr_log" &
+        fi
+        echo $! > "$pid_file"
+        if ! is_running; then
+            echo "Unable to start, see $stdout_log and $stderr_log"
+            exit 1
+        fi
+    fi
+    ;;
+    stop)
+    if is_running; then
+        echo -n "Stopping $name.."
+        kill `get_pid`
+        for i in 1 2 3 4 5 6 7 8 9 10
+        # for i in `seq 10`
+        do
+            if ! is_running; then
+                break
+            fi
+
+            echo -n "."
+            sleep 1
+        done
+        echo
+
+        if is_running; then
+            echo "Not stopped; may still be shutting down or shutdown may have failed"
+            exit 1
+        else
+            echo "Stopped"
+            if [ -f "$pid_file" ]; then
+                rm "$pid_file"
+            fi
+        fi
+    else
+        echo "Not running"
+    fi
+    ;;
+    restart)
+    $0 stop
+    if is_running; then
+        echo "Unable to stop, will not attempt to start"
+        exit 1
+    fi
+    $0 start
+    ;;
+    status)
+    if is_running; then
+        echo "Running"
+    else
+        echo "Stopped"
+        exit 1
+    fi
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/reboot-web.sh
+++ b/reboot-web.sh
@@ -45,7 +45,8 @@ rm -rf $SRV_BASE_DIR/$SRV_SUBDIR
 mv build $SRV_BASE_DIR/$SRV_SUBDIR
 
 echo "Starting server."
-cd $SRV_BASE_DIR
-/usr/local/bin/pushstate-server $SRV_SUBDIR &>/dev/null &
+# cd $SRV_BASE_DIR
+# /usr/local/bin/pushstate-server $SRV_SUBDIR &>/dev/null &
+apachectl restart
 
 exit 0;

--- a/reboot-web.sh
+++ b/reboot-web.sh
@@ -44,9 +44,8 @@ chmod 775 build
 rm -rf $SRV_BASE_DIR/$SRV_SUBDIR
 mv build $SRV_BASE_DIR/$SRV_SUBDIR
 
-echo "Starting server."
+# echo "Starting server."
 # cd $SRV_BASE_DIR
 # /usr/local/bin/pushstate-server $SRV_SUBDIR &>/dev/null &
-apachectl restart
 
 exit 0;

--- a/ssl-params.conf
+++ b/ssl-params.conf
@@ -1,0 +1,11 @@
+    SSLCipherSuite      EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
+    SSLProtocol         All -SSLv2 -SSLv3
+    SSLHonorCipherOrder On
+    Header              always set Strict-Transport-Security "max-age=63072000; includeSubdomains"
+    Header              always set X-Frame-Options DENY
+    Header              always set X-Content-Type-Options nosniff
+    SSLCompression      off
+    SSLSessionTickets   Off
+    SSLUseStapling      on
+    SSLStaplingCache    "shmcb:logs/stapling-cache(150000)"
+    SSLOpenSSLConfCmd   DHParameters "/etc/ssl/certs/dhparam.pem"

--- a/thevisual.conf
+++ b/thevisual.conf
@@ -1,0 +1,48 @@
+ServerName      thevisual.work
+DocumentRoot    /var/www/html
+
+<VirtualHost *:80>
+    ServerName      thevisual.work
+    ServerAdmin     jeff@thevisual.work
+    DocumentRoot    /var/www/html
+
+    ErrorLog        ${APACHE_LOG_DIR}/thevisual-error.log
+    CustomLog       ${APACHE_LOG_DIR}/thevisual-access.log combined
+
+    <Directory /var/www/html>
+        AllowOverride   All
+    </Directory>
+</VirtualHost>
+
+<IfModule mod_ssl.c>
+    <VirtualHost *:443>
+        ServerName          thevisual.work
+        ServerAdmin         jeff@thevisual.work
+        DocumentRoot        /var/www/html
+
+        ErrorLog            ${APACHE_LOG_DIR}/thevisual-ssl-error.log
+        CustomLog           ${APACHE_LOG_DIR}/thevisual-ssl-access.log combined
+
+        <Directory /var/www/html>
+            AllowOverride   All
+        </Directory>
+    
+        SSLEngine           on
+    
+        <FilesMatch "\.(cgi|shtml|phtml|php)$">
+            SSLOptions      +StdEnvVars
+        </FilesMatch>
+        <Directory /usr/lib/cgi-bin>
+            SSLOptions      +StdEnvVars
+        </Directory>
+    
+        SSLCertificateFile      /etc/ssl/certs/thevisual.crt
+        SSLCertificateKeyFile   /etc/ssl/private/thevisual.key
+    
+        BrowserMatch "MSIE [2-6]" \
+                       nokeepalive ssl-unclean-shutdown \
+                       downgrade-1.0 force-response-1.0
+    </VirtualHost>
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
We're switching HTTP servers from pushstate-server to Apache. Here's why:

## Downsides of pushstate-server
Previously, we've been using [pushstate-server](https://github.com/scottcorgan/pushstate-server) as our HTTP server for serving up the production-ready site, as recommended by React. It's a simple HTTP server that works with a specific HTML5 feature called Pushstate.

However, this is not how pushstate-server was really designed. It's not designed to be run on port 80 as the primary production server for a website. I've had to employ a series of hacks to allow pushstate to serve up content on port 80 while not running it as root. I also don't know about the security implications of this.

Furthermore, pushstate-server doesn't allow for HTTPS connections. There are some [alpha-stage projects](https://www.npmjs.com/package/https-pushstate-server) that provide this and even a [pull request](https://github.com/scottcorgan/pushstate-server/pull/77), but they are young and untested.

## Upsides of Apache
Switching to Apache means the site will behave more like any other site will. This means that assets will get served up in a standard way, the site assets can be combined with any other scripting language (like PHP), and Apache modules (rewrite, ssl, and others) will work with the portfolio. Guides for securing Apache installations are common, and Apache modules are very mature and reliable.

Ultimately, this means the project will be better-maintained and more robust. The web server should automatically restart when the server reboots. HTTPS will be supported. And we have flexibility for the server to behave... normally.