### PR TITLE
HTTP/2 Support

### DIFF
--- a/thevisual.conf
+++ b/thevisual.conf
@@ -19,42 +19,52 @@ DocumentRoot    /var/www/html
     <Directory /var/www/html>
         AllowOverride   All
     </Directory>
-    
-    # Redirect all HTTP traffic to HTTPS
-    RewriteEngine on
-    RewriteCond %{SERVER_NAME} =thevisual.work
-    RewriteRule ^ https://%{SERVER_NAME}%{REQUEST_URI} [END,NE,R=permanent]
+
+    <IfModule mod_http2.c>
+        <IfModule mod_ssl.c>
+            # Redirect all HTTP traffic to HTTPS
+            RewriteEngine on
+            RewriteCond %{SERVER_NAME} =thevisual.work
+            RewriteRule ^ https://%{SERVER_NAME}%{REQUEST_URI} [END,NE,R=permanent]
+        </IfModule>
+    </IfModule>
 </VirtualHost>
 
-<IfModule mod_ssl.c>
-    <VirtualHost *:443>
-        ServerName          thevisual.work
-        ServerAdmin         jeff@thevisual.work
-        DocumentRoot        /var/www/html
+<IfModule mod_http2.c>
+    Protocols       http/1.1
 
-        ErrorLog            ${APACHE_LOG_DIR}/thevisual-ssl-error.log
-        CustomLog           ${APACHE_LOG_DIR}/thevisual-ssl-access.log combined
+    <IfModule mod_ssl.c>
+        <VirtualHost *:443>
+            ServerName          thevisual.work
+            ServerAdmin         jeff@thevisual.work
+            DocumentRoot        /var/www/html
+            Protocols           h2 http/1.1
 
-        <Directory /var/www/html>
-            AllowOverride   All
-        </Directory>
-    
-        SSLEngine           on
-    
-        <FilesMatch "\.(cgi|shtml|phtml|php)$">
-            SSLOptions      +StdEnvVars
-        </FilesMatch>
-        <Directory /usr/lib/cgi-bin>
-            SSLOptions      +StdEnvVars
-        </Directory>
-    
-        SSLCertificateFile      /etc/letsencrypt/live/thevisual.work/fullchain.pem
-        SSLCertificateKeyFile   /etc/letsencrypt/live/thevisual.work/privkey.pem
-    
-        BrowserMatch "MSIE [2-6]" \
-                       nokeepalive ssl-unclean-shutdown \
-                       downgrade-1.0 force-response-1.0
-    </VirtualHost>
+            ErrorLog            ${APACHE_LOG_DIR}/thevisual-ssl-error.log
+            CustomLog           ${APACHE_LOG_DIR}/thevisual-ssl-access.log combined
+
+            <Directory /var/www/html>
+                AllowOverride   All
+            </Directory>
+
+            SSLEngine           on
+
+            <FilesMatch "\.(cgi|shtml|phtml|php)$">
+                SSLOptions      +StdEnvVars
+            </FilesMatch>
+            <Directory /usr/lib/cgi-bin>
+                SSLOptions      +StdEnvVars
+            </Directory>
+
+            # On the development server, these are self-
+            SSLCertificateFile      "/etc/ssl/certs/thevisual.crt"
+            SSLCertificateKeyFile   "/etc/ssl/private/thevisual.key"
+
+            BrowserMatch "MSIE [2-6]" \
+                           nokeepalive ssl-unclean-shutdown \
+                           downgrade-1.0 force-response-1.0
+        </VirtualHost>
+    </IfModule>
 </IfModule>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/thevisual.conf
+++ b/thevisual.conf
@@ -1,6 +1,13 @@
 ServerName      thevisual.work
 DocumentRoot    /var/www/html
 
+<If "%{HTTP_HOST} == 'thevisual.work'">
+    SetEnv          ENVIRONMENT_TYPE    "production"
+</If>
+<Else>
+    SetEnv          ENVIRONMENT_TYPE    "development"
+</Else>
+
 <VirtualHost *:80>
     ServerName      thevisual.work
     ServerAdmin     jeff@thevisual.work


### PR DESCRIPTION
HTTP/2, when supported server-side, allows for a much faster page load, even including the SSL negotiation.